### PR TITLE
Fix incompatibility with portable crafting table mods

### DIFF
--- a/src/main/java/ru/betterend/mixin/common/CraftingScreenHandlerMixin.java
+++ b/src/main/java/ru/betterend/mixin/common/CraftingScreenHandlerMixin.java
@@ -21,9 +21,10 @@ public abstract class CraftingScreenHandlerMixin
 
 	@Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
 	private void canUse(PlayerEntity player, CallbackInfoReturnable<Boolean> info) {
-		info.setReturnValue(context.run((world, pos) -> {
+		if (context.run((world, pos) -> {
 			return world.getBlockState(pos).getBlock() instanceof CraftingTableBlock;
-		}, true));
-		info.cancel();
+		}, true)) {
+			info.setReturnValue(true);
+		}
 	}
 }


### PR DESCRIPTION
Due to BetterEnd canceling `CraftingScreenHandler#canUse` at the head, conditions injected by other mods fail silently. This PR offers a simple fix, by only cancelling if the condition succeeds and falling back to other handlers otherwise.

This may be slightly less performant as the vanilla method will be called redundantly in case of failure, but that should only happen if the crafting table disappeared or if a mod is providing a portable crafting screen - which should be rare enough to not matter.

Side note: `setReturnValue` automatically calls `cancel`, hence me removing the latter. It could be re-added if it's a style preference.