### PR TITLE
Fix knockback resistance not being applied

### DIFF
--- a/src/main/java/ru/betterend/item/EndArmorItem.java
+++ b/src/main/java/ru/betterend/item/EndArmorItem.java
@@ -1,17 +1,49 @@
 package ru.betterend.item;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.Item;
+import ru.betterend.mixin.common.ArmorItemAccessor;
 import ru.betterend.patterns.Patterned;
 import ru.betterend.patterns.Patterns;
+
+import java.util.UUID;
 
 public class EndArmorItem extends ArmorItem implements Patterned {
 	public EndArmorItem(ArmorMaterial material, EquipmentSlot slot, Item.Settings settings) {
 		super(material, slot, settings);
+
+		addKnockbackResistance((ArmorItemAccessor) this, slot, this.knockbackResistance);
 	}
-	
+
+	/** Ensures knockback resistance is actually applied */
+	private static void addKnockbackResistance(ArmorItemAccessor accessor, EquipmentSlot slot, double knockbackResistance) {
+		if (knockbackResistance == 0) {
+			return;
+		}
+
+		Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers = accessor.getAttributeModifiers();
+
+		// In case Mojang or anyone else decided to fix this
+		if (attributeModifiers.keys().contains(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE)) {
+			return;
+		}
+
+		UUID uuid = accessor.getModifiers()[slot.getEntitySlotId()];
+
+		// Rebuild attributeModifiers to include knockback resistance
+		ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
+		builder.putAll(attributeModifiers);
+		builder.put(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, new EntityAttributeModifier(uuid, "Armor knockback resistance", knockbackResistance, EntityAttributeModifier.Operation.ADDITION));
+		accessor.setAttributeModifiers(builder.build());
+	}
+
 	@Override
 	public String getModelPattern(String name) {
 		return Patterns.createJson(Patterns.ITEM_GENERATED, name);

--- a/src/main/java/ru/betterend/mixin/common/ArmorItemAccessor.java
+++ b/src/main/java/ru/betterend/mixin/common/ArmorItemAccessor.java
@@ -1,0 +1,22 @@
+package ru.betterend.mixin.common;
+
+import com.google.common.collect.Multimap;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ArmorItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.UUID;
+
+@Mixin(ArmorItem.class)
+public interface ArmorItemAccessor {
+	@Accessor("MODIFIERS")
+	UUID[] getModifiers();
+
+	@Accessor("attributeModifiers")
+	Multimap<EntityAttribute, EntityAttributeModifier> getAttributeModifiers();
+
+	@Accessor("attributeModifiers")
+	void setAttributeModifiers(Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers);
+}

--- a/src/main/resources/betterend.mixins.common.json
+++ b/src/main/resources/betterend.mixins.common.json
@@ -4,6 +4,7 @@
 	"package": "ru.betterend.mixin.common",
 	"compatibilityLevel": "JAVA_8",
 	"mixins": [
+		"ArmorItemAccessor",
 		"EnchantmentScreenHandlerMixin",
 		"PlayerAdvancementTrackerMixin",
 		"CraftingScreenHandlerMixin",


### PR DESCRIPTION
Despite being set in the [Materials](https://github.com/paulevsGitch/BetterEnd/blob/2403907b0dc42d0cde5900f3b3bc3cf3e9792a2b/src/main/java/ru/betterend/item/material/EndArmorMaterial.java#L20), the knockback resistance isn't actually applied because Mojang only puts the `EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE` when the used material is `NETHERITE`, instead of simply checking if `knockbackResistance > 0` or `!= 0`...

That's why a workaround such as this is necessary.

This PR adds an accessor for the `attributeModifiers`, copies the values into a new map and adds the knockback resistance if needed.
There's also a check if the knockback resistance is already there, in case this issue somehow got fixed.