### PR TITLE
Fix cubozoa and end fish getting smaller after every reload

### DIFF
--- a/src/main/java/ru/betterend/entity/CubozoaEntity.java
+++ b/src/main/java/ru/betterend/entity/CubozoaEntity.java
@@ -75,7 +75,7 @@ public class CubozoaEntity extends SchoolingFishEntity {
 	public void writeCustomDataToTag(CompoundTag tag) {
 		super.writeCustomDataToTag(tag);
 		tag.putByte("Variant", (byte) getVariant());
-		tag.putByte("Scale", (byte) getScale());
+		tag.putByte("Scale", dataTracker.get(SCALE));
 	}
 
 	@Override

--- a/src/main/java/ru/betterend/entity/EndFishEntity.java
+++ b/src/main/java/ru/betterend/entity/EndFishEntity.java
@@ -69,7 +69,7 @@ public class EndFishEntity extends SchoolingFishEntity {
 	public void writeCustomDataToTag(CompoundTag tag) {
 		super.writeCustomDataToTag(tag);
 		tag.putByte("Variant", (byte) getVariant());
-		tag.putByte("Scale", (byte) getScale());
+		tag.putByte("Scale", dataTracker.get(SCALE));
 	}
 
 	@Override


### PR DESCRIPTION
Previously, getScale() was used to get the size value when saving the
entity to NBT. However, this means that the entities will get
progressively smaller, since getScale() divides the true scale before
returning it. This commit fixes this by getting the 'raw' scale directly
from the dataTracker when saving the scale to NBT.