### PR TITLE
Fix end stone smelter not giving exp on shift-click

### DIFF
--- a/src/main/java/ru/betterend/client/gui/EndStoneSmelterScreenHandler.java
+++ b/src/main/java/ru/betterend/client/gui/EndStoneSmelterScreenHandler.java
@@ -128,7 +128,7 @@ public class EndStoneSmelterScreenHandler extends RecipeBookMenu<Container> {
 			ItemStack itemStack2 = slot.getItem();
 			itemStack = itemStack2.copy();
 			if (index == 3) {
-				if (moveItemStackTo(itemStack2, 4, 40, true)) {
+				if (!moveItemStackTo(itemStack2, 4, 40, true)) {
 					return ItemStack.EMPTY;
 				}
 				slot.onQuickCraft(itemStack2, itemStack);


### PR DESCRIPTION
This is a one character buggfix for a bug that prevented players from
getting exp when shift-clicking the output slot to retrieve the smelted
item. See this for the original Forge issue that made me aware of the
bug: https://github.com/Beethoven92/BetterEndForge/issues/85