### PR TITLE
Add integration with Inventory Profiles Next for End Stone Smelter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     } else {
         useApi "com.github.paulevsGitch:BCLib:${project.bclib_version}"
     }
-    useApi "org.anti-ad.mc:inventory-profiles-next:fabric-1.17.1-${project.ipn_version}"
 
     useOptional "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
     useOptional "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     } else {
         useApi "com.github.paulevsGitch:BCLib:${project.bclib_version}"
     }
+    useApi "org.anti-ad.mc:inventory-profiles-next:fabric-1.17.1-${project.ipn_version}"
 
     useOptional "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
     useOptional "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
@@ -70,6 +71,7 @@ def useApi(String dep) {
     dependencies.modApi(dep) {
         exclude group: 'net.fabricmc.fabric-api'
         exclude group: 'net.fabricmc'
+        exclude group: 'com.terraformersmc'
         if (!dep.contains("me.shedaniel")) {
             exclude group: 'me.shedaniel.cloth'
             exclude group: 'me.shedaniel'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,13 @@ loader_version=0.11.6
 mod_version=0.12.0-pre
 maven_group=ru.betterend
 archives_base_name=better-end
+
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
+
 patchouli_version = 55-FABRIC-SNAPSHOT
 fabric_version = 0.36.1+1.17
 bclib_version = 0.4.1
 rei_version = 6.0.264-alpha
 canvas_version = 1.0.+
+ipn_version=1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@ fabric_version = 0.36.1+1.17
 bclib_version = 0.4.1
 rei_version = 6.0.264-alpha
 canvas_version = 1.0.+
-ipn_version=1.1.0

--- a/src/main/java/org/anti_ad/mc/ipn/api/IPNIgnore.java
+++ b/src/main/java/org/anti_ad/mc/ipn/api/IPNIgnore.java
@@ -1,0 +1,8 @@
+package org.anti_ad.mc.ipn.api;
+
+import java.lang.annotation.*;
+
+// Included from "Inventory Profiles Next" (https://github.com/blackd/Inventory-Profiles)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IPNIgnore {}

--- a/src/main/java/ru/betterend/client/gui/EndStoneSmelterScreenHandler.java
+++ b/src/main/java/ru/betterend/client/gui/EndStoneSmelterScreenHandler.java
@@ -18,6 +18,7 @@ import net.minecraft.world.inventory.StackedContentsCompatible;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
+import org.anti_ad.mc.ipn.api.IPNIgnore;
 import ru.betterend.BetterEnd;
 import ru.betterend.blocks.EndStoneSmelter;
 import ru.betterend.blocks.entities.EndStoneSmelterBlockEntity;
@@ -25,6 +26,7 @@ import ru.betterend.client.gui.slot.SmelterFuelSlot;
 import ru.betterend.client.gui.slot.SmelterOutputSlot;
 import ru.betterend.recipe.builders.AlloyingRecipe;
 
+@IPNIgnore
 public class EndStoneSmelterScreenHandler extends RecipeBookMenu<Container> {
 	
 	public final static MenuType<EndStoneSmelterScreenHandler> HANDLER_TYPE = ScreenHandlerRegistry.registerSimple(


### PR DESCRIPTION
Since IPN doesn't recognise that the End Stone Smelter as a Smelter it adds it's UI as in this picture:

![2021-10-17_13 36 42-only-endstone-smelter](https://user-images.githubusercontent.com/333840/137623797-d76d5fa8-2d2f-4e50-9d63-efab9ad4e229.png)

It will also try to sort the slots of the smelter. 
The proposed change add an annotation to ```EndStoneSmelterScreenHandler``` which tells IPN not to mess with it.

I've tested this with the tag of the latest release, because I was not able to build the current master.