### PR TITLE
Made sky rendering work with the new fabric api.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ archives_base_name=better-end
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 
 patchouli_version = 55-FABRIC-SNAPSHOT
-fabric_version = 0.41.3+1.17
+fabric_version = 0.42.1+1.17
 bclib_version = 0.5.2
 rei_version = 6.0.264-alpha
 canvas_version = 1.0.+

--- a/src/main/java/ru/betterend/client/BetterEndClient.java
+++ b/src/main/java/ru/betterend/client/BetterEndClient.java
@@ -2,14 +2,19 @@ package ru.betterend.client;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.DimensionRenderingRegistry;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+
 import ru.bclib.BCLib;
 import ru.bclib.util.TranslationHelper;
 import ru.betterend.BetterEnd;
+import ru.betterend.client.render.BetterEndSkyRenderer;
 import ru.betterend.events.ItemTooltipCallback;
 import ru.betterend.interfaces.MultiModelItem;
 import ru.betterend.item.CrystaliteArmor;
@@ -52,6 +57,12 @@ public class BetterEndClient implements ClientModInitializer {
 			}
 			return null;
 		});
+
+		BetterEndSkyRenderer skyRenderer = new BetterEndSkyRenderer();
+
+		if(ClientOptions.isCustomSky()) {
+			DimensionRenderingRegistry.registerSkyRenderer(Level.END, skyRenderer);
+		}
 	}
 	
 	public static void registerTooltips() {

--- a/src/main/java/ru/betterend/mixin/client/LevelRendererAccessor.java
+++ b/src/main/java/ru/betterend/mixin/client/LevelRendererAccessor.java
@@ -1,0 +1,12 @@
+package ru.betterend.mixin.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.renderer.LevelRenderer;
+
+@Mixin(LevelRenderer.class)
+public interface LevelRendererAccessor {
+    @Accessor("ticks")
+    int getTick();
+}

--- a/src/main/resources/betterend.mixins.client.json
+++ b/src/main/resources/betterend.mixins.client.json
@@ -5,19 +5,21 @@
 	"compatibilityLevel": "JAVA_16",
 	"client": [
 		"AbstractSoundInstanceAccessor",
-		"HumanoidMobRendererMixin",
 		"ArmorStandRendererMixin",
-		"MinecraftClientMixin",
-        "PlayerRendererMixin",
-		"LevelRendererMixin",
-		"MusicTrackerMixin",
 		"BiomeColorsMixin",
+		"CapeLayerMixin",
+		"HumanoidMobRendererMixin",
+		"ItemStackMixin",
+		"LocalPlayerMixin",
+		"MinecraftClientMixin",
 		"ModelLoaderMixin",
-        "LocalPlayerMixin",
-        "CapeLayerMixin",
-        "ItemStackMixin"
+		"MusicTrackerMixin",
+		"PlayerRendererMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1
-	}
+	},
+	"mixins": [
+		"LevelRendererAccessor"
+	]
 }

--- a/src/main/resources/betterend.mixins.client.json
+++ b/src/main/resources/betterend.mixins.client.json
@@ -14,12 +14,10 @@
 		"MinecraftClientMixin",
 		"ModelLoaderMixin",
 		"MusicTrackerMixin",
-		"PlayerRendererMixin"
+		"PlayerRendererMixin",
+		"LevelRendererAccessor"
 	],
 	"injectors": {
 		"defaultRequire": 1
-	},
-	"mixins": [
-		"LevelRendererAccessor"
-	]
+	}
 }


### PR DESCRIPTION
So I'm one of the devs of Dimensional Doors. I made the new DimensionRenderingRegistry from the fabric api. A system in dimdoors that allows the usage of world's sky rendering is dependent on it. I play on a server with BetterEnd and Dimdoors on it. Really enjoy the upgrade to the end's sky so I thought it would be cool to have it render in pockets with the end sky. So here we are!