### PR TITLE
Properly tag betterend's biomes as c:in_the_end biome tag

### DIFF
--- a/src/main/resources/data/c/tags/worldgen/biome/in_the_end.json
+++ b/src/main/resources/data/c/tags/worldgen/biome/in_the_end.json
@@ -1,0 +1,30 @@
+{
+  "replace": false,
+  "values": [
+    "betterend:amber_land",
+    "betterend:blossoming_spires",
+    "betterend:chorus_forest",
+    "betterend:crystal_mountains",
+    "betterend:dragon_graveyards",
+    "betterend:dry_shrubland",
+    "betterend:dust_wasteland",
+    "betterend:empty_aurora_cave",
+    "betterend:empty_end_cave",
+    "betterend:empty_smaragdant_cave",
+    "betterend:foggy_mushroomland",
+    "betterend:glowing_grassland",
+    "betterend:ice_starfield",
+    "betterend:jade_cave",
+    "betterend:lantern_woods",
+    "betterend:lush_aurora_cave",
+    "betterend:lush_smaragdant_cave",
+    "betterend:megalake",
+    "betterend:megalake_grove",
+    "betterend:neon_oasis",
+    "betterend:painted_mountains",
+    "betterend:shadow_forest",
+    "betterend:sulphur_springs",
+    "betterend:umbra_valley",
+    "betterend:umbrella_jungle"
+  ]
+}


### PR DESCRIPTION
With the merger of Fabric API's common biome tags, all biome mods should now properly tag their biomes to maximize compat. Currently, mods using the c:in_the_end biome tag for their json structures will not spawn in betterend biomes. Which is problematic. 

This aims to resolve that. Biome tags were added by mojang in 1.18.2

Fabric API common biome tag pr: https://github.com/FabricMC/fabric/tree/1d2d03ecd5a4508d14d4bf0647324afef1b8d2bd/fabric-convention-tags-v1/src/generated/resources/data/c/tags/worldgen/biome